### PR TITLE
Update configuration to support Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   set-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       tests: ${{ steps.set-matrix.outputs.tests }}
     steps:
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         tests: ${{ fromJSON(needs.set-matrix.outputs.tests) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx
@@ -43,7 +43,7 @@ jobs:
 
   ci-complete:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: always()
     steps:
       - name: Check if all jobs succeeded

--- a/.github/workflows/scripts/ci_matrix
+++ b/.github/workflows/scripts/ci_matrix
@@ -7,14 +7,14 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
 pretty_os() {
     case "${1}" in
     arch) echo "arch" ;;
-    ubuntu_22_04) echo "ubuntu-22.04" ;;
+    ubuntu_24_04) echo "ubuntu-24.04" ;;
     debian_12) echo "debian-12" ;;
     rocky_9) echo "rocky-9" ;;
     *) echo "${1}" ;;
     esac
 }
 
-declare -a os_list=(arch ubuntu_22_04 debian_12 rocky_9)
+declare -a os_list=(arch ubuntu_24_04 debian_12 rocky_9)
 
 declare first_entry=true
 dump_entry() {

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All available modules can be listed by running the `install --list-modules`.
 ## Supported OS
 
 * Arch Linux
-* Ubuntu 22.04 (Jammy Jellyfish)
+* Ubuntu 24.04 (Noble Numbat)
 * Debian 12 (Bookworm)
 * Rocky Linux 9
 

--- a/lib/common/os.bash
+++ b/lib/common/os.bash
@@ -1,7 +1,7 @@
 is_supported_os() {
     local os_id="${1}"
     case "${os_id}" in
-    "${OS_ARCH}" | "${OS_UBUNTU_22_04}" | "${OS_DEBIAN_12}" | "${OS_ROCKY_9}") return 0 ;;
+    "${OS_ARCH}" | "${OS_UBUNTU_24_04}" | "${OS_DEBIAN_12}" | "${OS_ROCKY_9}") return 0 ;;
     *) return 1 ;;
     esac
 }
@@ -41,7 +41,7 @@ _init_os() {
 }
 
 readonly OS_ARCH="arch"
-readonly OS_UBUNTU_22_04="ubuntu-22.04"
+readonly OS_UBUNTU_24_04="ubuntu-24.04"
 readonly OS_DEBIAN_12="debian-12"
 readonly OS_ROCKY_9="rocky-9"
 OS_ID="$(_print_os_id)"

--- a/lib/common/package.bash
+++ b/lib/common/package.bash
@@ -313,7 +313,7 @@ install_package_by_spec() {
         "${OS_ARCH}")
             install_package_arch "${package_and_sources[@]}"
             ;;
-        "${OS_UBUNTU_22_04}" | "${OS_DEBIAN_12}")
+        "${OS_UBUNTU_24_04}" | "${OS_DEBIAN_12}")
             install_package_debian "${package_and_sources[@]}"
             ;;
         "${OS_ROCKY_9}")

--- a/modules/bat.bash
+++ b/modules/bat.bash
@@ -2,13 +2,13 @@
 
 install_package_by_spec <<END
     arch: bat
-    ubuntu-22.04: bat
+    ubuntu-24.04: bat
     debian-12: bat
     rocky-9: bat@epel
 END
 
 case "${OS_ID}" in
-"${OS_UBUNTU_22_04}" | "${OS_DEBIAN_12}")
+"${OS_UBUNTU_24_04}" | "${OS_DEBIAN_12}")
     SUDO=true ensure_symlink_exists /usr/bin/batcat /usr/local/bin/bat
     ;;
 esac

--- a/modules/cargo_binstall.bash
+++ b/modules/cargo_binstall.bash
@@ -7,7 +7,7 @@ if ! command -v cargo-binstall >/dev/null; then
     "${OS_ARCH}")
         pacman_install cargo-binstall
         ;;
-    "${OS_UBUNTU_22_04}" | "${OS_DEBIAN_12}" | "${OS_ROCKY_9}")
+    "${OS_UBUNTU_24_04}" | "${OS_DEBIAN_12}" | "${OS_ROCKY_9}")
         install_module curl
         ACTION="installing cargo-binstall" execute bash -c "curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash"
         ;;

--- a/modules/cargo_update.bash
+++ b/modules/cargo_update.bash
@@ -4,7 +4,7 @@ install_module rustup
 
 install_package_by_spec <<END
     arch: cargo-update
-    ubuntu-22.04: cargo-update@cargo
+    ubuntu-24.04: cargo-update@cargo
     debian-12: cargo-update@cargo
     rocky-9: cargo-update@cargo
 END

--- a/modules/curl.bash
+++ b/modules/curl.bash
@@ -3,7 +3,7 @@
 if ! command -v curl >/dev/null; then
     install_package_by_spec <<END
         arch: curl
-        ubuntu-22.04: curl ca-certificates
+        ubuntu-24.04: curl ca-certificates
         debian-12: curl ca-certificates
         rocky-9: curl-minimal
 END

--- a/modules/delta.bash
+++ b/modules/delta.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: git-delta
-    ubuntu-22.04: git-delta@cargo
+    ubuntu-24.04: git-delta@cargo
     debian-12: git-delta@cargo
     rocky-9: git-delta@cargo
 END

--- a/modules/devtools.bash
+++ b/modules/devtools.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: base-devel
-    ubuntu-22.04: build-essential
+    ubuntu-24.04: build-essential
     debian-12: build-essential
     rocky-9: $(pkg_encode <<<"@Development Tools")
 END

--- a/modules/emacs.bash
+++ b/modules/emacs.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: emacs
-    ubuntu-22.04: emacs
+    ubuntu-24.04: emacs
     debian-12: emacs
     rocky-9: emacs
 END

--- a/modules/eza.bash
+++ b/modules/eza.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: eza
-    ubuntu-22.04: eza@cargo
+    ubuntu-24.04: eza@cargo
     debian-12: eza@cargo
     rocky-9: eza@cargo
 END

--- a/modules/fzf.bash
+++ b/modules/fzf.bash
@@ -12,7 +12,7 @@ if [[ "${OS_ID}" == "${OS_ROCKY_9}" ]]; then
 else
     install_package_by_spec <<END
         arch: fzf
-        ubuntu-22.04: fzf
+        ubuntu-24.04: fzf
         debian-12: fzf
 END
     assert_command fzf

--- a/modules/git.bash
+++ b/modules/git.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: git
-    ubuntu-22.04: git ca-certificates
+    ubuntu-24.04: git ca-certificates
     debian-12: git ca-certificates
     rocky-9: git
 END

--- a/modules/keychain.bash
+++ b/modules/keychain.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: keychain
-    ubuntu-22.04: keychain
+    ubuntu-24.04: keychain
     debian-12: keychain
     rocky-9: keychain@epel
 END

--- a/modules/nushell.bash
+++ b/modules/nushell.bash
@@ -5,7 +5,7 @@ install_module git
 
 install_package_by_spec <<END
     arch: nushell
-    ubuntu-22.04: nu@cargo
+    ubuntu-24.04: nu@cargo
     debian-12: nu@cargo
     rocky-9: nu@epel
 END

--- a/modules/ripgrep.bash
+++ b/modules/ripgrep.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: ripgrep
-    ubuntu-22.04: ripgrep
+    ubuntu-24.04: ripgrep
     debian-12: ripgrep
     rocky-9: ripgrep@epel
 END

--- a/modules/sheldon.bash
+++ b/modules/sheldon.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: sheldon
-    ubuntu-22.04: sheldon@cargo
+    ubuntu-24.04: sheldon@cargo
     debian-12: sheldon@cargo
     rocky-9: sheldon@cargo
 END

--- a/modules/skim.bash
+++ b/modules/skim.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: skim
-    ubuntu-22.04: skim@cargo
+    ubuntu-24.04: skim@cargo
     debian-12: skim@cargo
     rocky-9: skim@cargo
 END

--- a/modules/souko.bash
+++ b/modules/souko.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: souko-bin@aur
-    ubuntu-22.04: souko@cargo
+    ubuntu-24.04: souko@cargo
     debian-12: souko@cargo
     rocky-9: souko@cargo
 END

--- a/modules/starship.bash
+++ b/modules/starship.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: starship
-    ubuntu-22.04: starship@cargo
+    ubuntu-24.04: starship@cargo
     debian-12: starship@cargo
     rocky-9: starship@cargo
 END

--- a/modules/tig.bash
+++ b/modules/tig.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: tig
-    ubuntu-22.04: tig
+    ubuntu-24.04: tig
     debian-12: tig
     rocky-9: tig@epel
 END

--- a/modules/tmux.bash
+++ b/modules/tmux.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: tmux
-    ubuntu-22.04: tmux
+    ubuntu-24.04: tmux
     debian-12: tmux
     rocky-9: tmux
 END

--- a/modules/topgrade.bash
+++ b/modules/topgrade.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: topgrade-bin@aur
-    ubuntu-22.04: topgrade@cargo
+    ubuntu-24.04: topgrade@cargo
     debian-12: topgrade@cargo
     rocky-9: topgrade@cargo
 END

--- a/modules/vim.bash
+++ b/modules/vim.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: vim
-    ubuntu-22.04: vim
+    ubuntu-24.04: vim
     debian-12: vim
     rocky-9: vim
 END

--- a/modules/zellij.bash
+++ b/modules/zellij.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: zellij
-    ubuntu-22.04: zellij@cargo
+    ubuntu-24.04: zellij@cargo
     debian-12: zellij@cargo
     rocky-9: zellij@cargo
 END

--- a/modules/zoxide.bash
+++ b/modules/zoxide.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: zoxide
-    ubuntu-22.04: zoxide
+    ubuntu-24.04: zoxide
     debian-12: zoxide
     rocky-9: zoxide@cargo
 END

--- a/modules/zsh.bash
+++ b/modules/zsh.bash
@@ -2,7 +2,7 @@
 
 install_package_by_spec <<END
     arch: zsh
-    ubuntu-22.04: zsh
+    ubuntu-24.04: zsh
     debian-12: zsh
     rocky-9: zsh util-linux-user
 END

--- a/test/Makefile
+++ b/test/Makefile
@@ -76,17 +76,17 @@ $(WORK_DIR)/build-image-%-install-dry_run.stamp: docker/Dockerfile.% | $(WORK_DI
 
 build-image-arch-bootstrap: $(WORK_DIR)/$$@.stamp
 build-image-debian_12-bootstrap: $(WORK_DIR)/$$@.stamp
-build-image-ubuntu_22_04-bootstrap: $(WORK_DIR)/$$@.stamp
+build-image-ubuntu_24_04-bootstrap: $(WORK_DIR)/$$@.stamp
 build-image-rocky_9-bootstrap: $(WORK_DIR)/$$@.stamp
 
 build-image-arch-install-normal: $(WORK_DIR)/$$@.stamp
 build-image-debian_12-install-normal: $(WORK_DIR)/$$@.stamp
-build-image-ubuntu_22_04-install-normal: $(WORK_DIR)/$$@.stamp
+build-image-ubuntu_24_04-install-normal: $(WORK_DIR)/$$@.stamp
 build-image-rocky_9-install-normal: $(WORK_DIR)/$$@.stamp
 
 build-image-arch-install-dry_run: $(WORK_DIR)/$$@.stamp
 build-image-debian_12-install-dry_run: $(WORK_DIR)/$$@.stamp
-build-image-ubuntu_22_04-install-dry_run: $(WORK_DIR)/$$@.stamp
+build-image-ubuntu_24_04-install-dry_run: $(WORK_DIR)/$$@.stamp
 build-image-rocky_9-install-dry_run: $(WORK_DIR)/$$@.stamp
 
 run-%-bootstrap: CONTAINER_NAME ?= dotfiles-test-$(patsubst run-%,%,$@)
@@ -133,15 +133,15 @@ run-%-install-dry_run: build-image-%-install-dry_run $(ARCHIVE) FORCE
 
 run-arch-bootstrap:
 run-debian_12-bootstrap:
-run-ubuntu_22_04-bootstrap:
+run-ubuntu_24_04-bootstrap:
 run-rocky_9-bootstrap:
 
 run-arch-install-normal:
 run-debian_12-install-normal:
-run-ubuntu_22_04-install-normal:
+run-ubuntu_24_04-install-normal:
 run-rocky_9-install-normal:
 
 run-arch-install-dry_run:
 run-debian_12-install-dry_run:
-run-ubuntu_22_04-install-dry_run:
+run-ubuntu_24_04-install-dry_run:
 run-rocky_9-install-dry_run:

--- a/test/docker/Dockerfile.ubuntu_24_04
+++ b/test/docker/Dockerfile.ubuntu_24_04
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG bootstrap=false
 ARG dry_run=false


### PR DESCRIPTION
Replace references to Ubuntu 22.04 with 24.04 in the CI configuration and install scripts to ensure compatibility with the latest Ubuntu version.